### PR TITLE
Fixed: Remove property when call has property.

### DIFF
--- a/Shared/CGICalendarComponent.m
+++ b/Shared/CGICalendarComponent.m
@@ -121,7 +121,6 @@ NSUInteger const CGICalendarComponentSequenceDefault = 0;
 - (BOOL)hasPropertyForName:(NSString *)name {
 	for (CGICalendarProperty *icalProp in [self properties]) {
 		if ([icalProp isName:name]) {
-			[[self properties] removeObject:icalProp];
 			return YES;
 		}
 	}


### PR DESCRIPTION
When call hasPropertyForName:, it will remove that property!!! That doesn't make sense.
