### PR TITLE
Modified to unescape escape sequences in value strings

### DIFF
--- a/Shared/CGICalendar.h
+++ b/Shared/CGICalendar.h
@@ -32,6 +32,7 @@ extern NSString * const CGICalendarFooterContentline;
 - (CGICalendarObject *)objectAtIndex:(NSUInteger)index;
 
 @property (nonatomic, readonly) NSString *description;
++ (NSString *)unescape:(NSString *)aValue;
 
 - (BOOL)writeToFile:(NSString *)path;
 

--- a/Shared/CGICalendar.m
+++ b/Shared/CGICalendar.m
@@ -125,7 +125,10 @@ NSString * const CGICalendarFooterContentline = @"END:VCALENDAR";
 			[self popParserObject];
 			continue;
 		}
-
+		
+		// Unescape escape sequences in value strings
+		icalContentLine.value = [CGICalendar unescape:icalContentLine.value];
+		
 		NSString *propertyName = icalContentLine.name;
 		CGICalendarProperty *icalProperty = [icalParentComponent propertyForName: propertyName];
 		if (!icalProperty) {
@@ -178,6 +181,36 @@ NSString * const CGICalendarFooterContentline = @"END:VCALENDAR";
 		[descriptionString appendString: icalObject.description];
 
 	return descriptionString;
+}
+
+// Replace double-escaped sequences in values imported from the iCal with the appropriate escape sequences
++ (NSString *)unescape:(NSString *)aValue
+{
+	// For slashes
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\\\" withString:@"\\"];
+	// For double quotes
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\\"" withString:@"\""];
+	// For single quotes
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\\'" withString:@"\'"];
+	// For line breaks
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\n" withString:@"\n"];
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\N" withString:@"\n"];
+	// For carriage returns
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\r" withString:@"\r"];
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\R" withString:@"\r"];
+	// For form feeds
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\f" withString:@"\f"];
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\F" withString:@"\f"];
+	// For tabs
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\t" withString:@"\t"];
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\T" withString:@"\t"];
+	// For commas
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\," withString:@","];
+	// For semicolons
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\;" withString:@";"];
+	// For colons
+	aValue = [aValue stringByReplacingOccurrencesOfString:@"\\:" withString:@":"];
+	return aValue;
 }
 
 #pragma mark -


### PR DESCRIPTION
In the process of using this library for iCal parsing for an iOS app, I noticed that the library was failing to convert escape sequences in the iCal values to NSString escape sequences, causing escape sequences (\n line breaks, \t tabs, : colons, ; semicolons, , commas, etc.) to appear in the strings instead of the special characters they are supposed to represent. I added some code to convert these, and all the escape sequences defined in iCalendar, to NSString escape sequences to fix this bug, and decided to commit these changes upstream to the iCal4ObjC project.